### PR TITLE
初始化死锁导致主线程卡顿3s

### DIFF
--- a/soter-client-sdk/soter-core/src/main/java/com/tencent/soter/core/sotercore/SyncJob.java
+++ b/soter-client-sdk/soter-core/src/main/java/com/tencent/soter/core/sotercore/SyncJob.java
@@ -14,6 +14,9 @@ public class SyncJob {
 
     private static Handler mMainLooperHandler = null;
 
+    // soter在某些机型上初始化，当 SoterCore 的 getProviderSoterCore 为 NULL 时，会在 SoterCoreTreble 中绑定 ISoterService
+    // SoterCoreTreble 的 mServiceConnection 连接成功后，在 onServiceConnected 中调用 countDown 该方法会发生必现的死锁现象，导致主线程卡顿 3s
+    // 只有等 countDownWait.await 3秒后释放锁后，这里才会继续执行，主线程恢复。
     public synchronized void countDown(){
         if (countDownWait != null) {
             countDownWait.countDown();


### PR DESCRIPTION
soter在某些机型上初始化，当 SoterCore 的 getProviderSoterCore 为 NULL 时，会在 SoterCoreTreble 中绑定 ISoterService
SoterCoreTreble 的 mServiceConnection 连接成功后，在 onServiceConnected 中调用 countDown 该方法会发生必现的死锁现象，导致主线程卡顿 3s
只有等 countDownWait.await 3秒后释放锁后，这里才会继续执行，主线程恢复。